### PR TITLE
Harden guards

### DIFF
--- a/hooks/guard-bash-substitutes.js
+++ b/hooks/guard-bash-substitutes.js
@@ -28,6 +28,12 @@
  */
 
 const fs = require('fs');
+const {
+  firstCommandWord,
+  splitTopLevel,
+  upstreamOfPipe,
+  isMultilineOrHeredoc,
+} = require('./lib/bash-parse');
 
 const CONTENT_SEARCH = /^(grep|rg|egrep|fgrep)$/;
 const FILE_READ = /^(cat|head|tail)$/;
@@ -43,20 +49,10 @@ function block(reason) {
   process.exit(0);
 }
 
-function firstCommandWord(segment) {
-  // Skip leading env assignments (FOO=bar cmd ...) and extract the command.
-  const tokens = segment.trim().split(/\s+/);
-  let i = 0;
-  while (i < tokens.length && /^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i])) i++;
-  if (i >= tokens.length) return '';
-  // Strip any path prefix (/usr/bin/grep -> grep).
-  return tokens[i].split('/').pop();
-}
-
 function checkSegment(segment) {
   // For a pipeline, only check the UPSTREAM command.
   // `cat a | grep b` -> check `cat a`, not the downstream `grep b`.
-  const firstPipePart = segment.split(/\|(?!\|)/)[0].trim();
+  const firstPipePart = upstreamOfPipe(segment);
   if (!firstPipePart) return null;
 
   const word = firstCommandWord(firstPipePart);
@@ -99,17 +95,12 @@ function main() {
 
   // Fail open on multi-line or heredoc commands — naive splitting would
   // misattribute and too-eagerly block.
-  if (cmd.includes('\n') || cmd.includes('<<')) return allow();
+  if (isMultilineOrHeredoc(cmd)) return allow();
 
   // Explicit escape hatch.
   if (/#\s*bash-guard:\s*allow\b/.test(cmd)) return allow();
 
-  // Split on top-level compound operators. Naive: does not track quoting, so
-  // a quoted ';' or '&&' inside a string argument will over-split. That is
-  // acceptable because we only flag matches, and any over-split segment that
-  // happens to start with a forbidden word was probably legitimate bash. In
-  // practice the wins on grep/cat/find dominate the rare false positive.
-  const segments = cmd.split(/(?:&&|\|\||;)/).map((s) => s.trim()).filter(Boolean);
+  const segments = splitTopLevel(cmd);
 
   for (const seg of segments) {
     const violation = checkSegment(seg);
@@ -117,6 +108,9 @@ function main() {
       return block(
         `guard-bash-substitutes: bash '${violation.word}' is blocked. ${violation.hint} ` +
           `(Use the ${violation.tool} tool instead.) ` +
+          `All common workarounds are also blocked: absolute paths (/usr/bin/${violation.word}), ` +
+          `quoted ("${violation.word}"), backslash-escape (\\${violation.word}), and launcher wrappers ` +
+          `(command/exec/builtin/env ${violation.word}). Do not retry variants — switch to the ${violation.tool} tool. ` +
           `If you genuinely need the shell version, append "# bash-guard: allow" to the command.`,
       );
     }

--- a/hooks/guard-git-push.js
+++ b/hooks/guard-git-push.js
@@ -1,21 +1,92 @@
 #!/usr/bin/env node
+/**
+ * PreToolUse hook for Bash.
+ *
+ * Purpose: block `git push` with arguments (destructive force-push etc.)
+ * while allowing the two safe forms: bare `git push` and the exact
+ * `git push origin main`.
+ *
+ * Bypass closure (matches guard-bash-substitutes semantics):
+ *   - Path prefix:       `/usr/bin/git push -f`       → blocked
+ *   - Quotes:            `"git" push -f`              → blocked
+ *   - Backslash-escape:  `\git push -f`               → blocked
+ *   - Launcher wrappers: `command|exec|builtin|env git push -f` → blocked
+ *   - Pipelines:         `something && git push -f`   → blocked
+ *   - Pipe upstream:     `git push -f | tee log`      → blocked
+ *
+ * NOT closed (known limitation, matches guard-bash-substitutes):
+ *   - `sudo git push -f`, `nice git push -f`, `time git push -f` — these
+ *     wrappers have flag/arg semantics that would create false positives if
+ *     unwrapped naively. sudo would also prompt for a password
+ *     non-interactively, so it is not a practical bypass in this context.
+ *
+ * Escape hatch:
+ *   - `# git-push-guard: allow` appended to the command force-allows it.
+ *     Use when you need a one-off push form that the rule does not cover.
+ *
+ * Failure mode:
+ *   - Multi-line / heredoc commands fail open (not parsed).
+ *   - Any JSON parse error fails open.
+ */
+
 const fs = require('fs');
+const {
+  commandTokens,
+  splitTopLevel,
+  upstreamOfPipe,
+  isMultilineOrHeredoc,
+} = require('./lib/bash-parse');
+
+function allow() {
+  process.exit(0);
+}
+
+function block(reason) {
+  process.stdout.write(JSON.stringify({ decision: 'block', reason }));
+  process.exit(0);
+}
+
+function isForbiddenPush(segment) {
+  const upstream = upstreamOfPipe(segment);
+  if (!upstream) return false;
+  const tokens = commandTokens(upstream);
+  if (tokens[0] !== 'git') return false;
+  if (tokens[1] !== 'push') return false;
+  // Bare `git push` (no args) allowed.
+  if (tokens.length === 2) return false;
+  // Exactly `git push origin main` allowed.
+  if (tokens.length === 4 && tokens[2] === 'origin' && tokens[3] === 'main') return false;
+  return true;
+}
 
 function main() {
   let input;
   try {
     input = JSON.parse(fs.readFileSync(0, 'utf8'));
   } catch {
-    process.exit(0);
+    return allow();
   }
-  const cmd = (input.tool_input?.command || '').trim();
-  if (!/^git\s+push\s+/.test(cmd)) process.exit(0);
-  if (/^git\s+push\s+origin\s+main\s*$/.test(cmd)) process.exit(0);
-  process.stdout.write(JSON.stringify({
-    decision: 'block',
-    reason: 'git push with arguments is blocked. Use bare "git push" or run manually with ! git push <args>.',
-  }));
-  process.exit(0);
+
+  const cmd = (input.tool_input && input.tool_input.command) || '';
+  if (!cmd.trim()) return allow();
+  if (isMultilineOrHeredoc(cmd)) return allow();
+  if (/#\s*git-push-guard:\s*allow\b/.test(cmd)) return allow();
+
+  const segments = splitTopLevel(cmd);
+  for (const seg of segments) {
+    if (isForbiddenPush(seg)) {
+      return block(
+        'guard-git-push: git push with arguments is blocked. ' +
+          'Allowed forms: bare "git push" or exactly "git push origin main". ' +
+          'All common bypass forms are also blocked: absolute paths (/usr/bin/git), ' +
+          'quoted ("git"), backslash-escape (\\git), launcher wrappers ' +
+          '(command/exec/builtin/env git), and chained/piped forms (foo && git push -f). ' +
+          'Do not retry variants. Run manually with "! git push <args>", ' +
+          'or append "# git-push-guard: allow" to the command if you need a one-off exception.',
+      );
+    }
+  }
+  allow();
 }
 
 main();

--- a/hooks/guard-write.js
+++ b/hooks/guard-write.js
@@ -1,13 +1,14 @@
 #!/usr/bin/env node
 /**
- * PreToolUse hook for Write and Edit.
+ * PreToolUse hook for Write, Edit, and NotebookEdit.
  *
  * Purpose: prevent output-token waste from full-file rewrites via the Write tool
  * when an Edit would do.
  *
  * Rule:
  *   Block a Write when ALL of the following hold:
- *     1. The target file has already been touched (Write or Edit) earlier in this session.
+ *     1. The target file has already been touched (Write/Edit/NotebookEdit)
+ *        earlier in this session.
  *     2. The content being written is larger than THRESHOLD_CHARS.
  *     3. The exact same (file_path, content) Write was not previously blocked
  *        in this session (kill-switch: a second identical attempt goes through).
@@ -15,9 +16,11 @@
  *   Otherwise: allow. In particular, the *first* Write of a file in a session is
  *   always allowed — the rule only kicks in on repeat full rewrites.
  *
- *   For Edit calls: never block; just record the touch so subsequent Writes see it.
+ *   For Edit/NotebookEdit calls: never block; just record the touch so subsequent
+ *   Writes see it. (NotebookEdit is inherently per-cell, not full-file.)
  *
  * State is kept per session_id in $TMPDIR/claude-write-guard/<session_id>.json.
+ * Old state files are GC'd probabilistically (see STATE_TTL_MS / GC_PROBABILITY).
  * Any error in the hook fails open (allows the tool).
  */
 
@@ -28,6 +31,8 @@ const crypto = require('crypto');
 const THRESHOLD_CHARS = 3000;
 const STATE_DIR = path.join(process.env.TMPDIR || '/tmp', 'claude-write-guard');
 const MAX_BLOCKED_HASHES = 200;
+const STATE_TTL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const GC_PROBABILITY = 0.05; // ~1 in 20 invocations runs cleanup
 
 function allow() {
   // Exit 0 with no stdout = allow
@@ -64,6 +69,27 @@ function shortHash(s) {
   return crypto.createHash('sha256').update(s).digest('hex').slice(0, 16);
 }
 
+function gcOldState() {
+  // Best-effort: remove session state files older than STATE_TTL_MS. Swallow
+  // all errors — this is housekeeping, not correctness.
+  try {
+    const now = Date.now();
+    const entries = fs.readdirSync(STATE_DIR);
+    for (const name of entries) {
+      if (!name.endsWith('.json')) continue;
+      const file = path.join(STATE_DIR, name);
+      try {
+        const st = fs.statSync(file);
+        if (now - st.mtimeMs > STATE_TTL_MS) fs.unlinkSync(file);
+      } catch {
+        // per-file errors ignored
+      }
+    }
+  } catch {
+    // dir doesn't exist yet, or unreadable — fine
+  }
+}
+
 function main() {
   let input;
   try {
@@ -72,19 +98,24 @@ function main() {
     return allow();
   }
 
+  if (Math.random() < GC_PROBABILITY) gcOldState();
+
   const toolName = input.tool_name || '';
   const toolInput = input.tool_input || {};
   const sessionId = input.session_id || 'no-session';
-  const filePath = toolInput.file_path;
+  // Write/Edit use file_path; NotebookEdit uses notebook_path.
+  const filePath = toolInput.file_path || toolInput.notebook_path;
 
   if (!filePath) return allow();
-  if (toolName !== 'Write' && toolName !== 'Edit') return allow();
+  if (toolName !== 'Write' && toolName !== 'Edit' && toolName !== 'NotebookEdit') return allow();
 
   const state = loadState(sessionId);
   const prevTouches = state.touched[filePath] || 0;
 
-  // Edit: never blocks, always records.
-  if (toolName === 'Edit') {
+  // Edit and NotebookEdit: never block, always record. NotebookEdit is
+  // inherently per-cell, not a full-file rewrite, so the output-token waste
+  // concern doesn't apply.
+  if (toolName === 'Edit' || toolName === 'NotebookEdit') {
     state.touched[filePath] = prevTouches + 1;
     saveState(sessionId, state);
     return allow();

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -35,7 +35,7 @@
         "description": "Block bash grep/cat/find that duplicates Grep/Read/Glob tools"
       },
       {
-        "matcher": "Write|Edit",
+        "matcher": "Write|Edit|NotebookEdit",
         "hooks": [
           {
             "type": "command",

--- a/hooks/lib/bash-parse.js
+++ b/hooks/lib/bash-parse.js
@@ -1,0 +1,92 @@
+/**
+ * Shared bash-command parsing helpers for PreToolUse hooks.
+ *
+ * The hooks are narrow regex-based guards, not real shell parsers. These
+ * helpers centralize the small amount of tokenization, unwrapping, and
+ * segment-splitting they need so that bypass-closure work happens in one
+ * place.
+ *
+ * Limitations (shared across consumers):
+ *   - No quoting awareness: a literal `;`/`&&`/`||` inside a quoted arg will
+ *     over-split. Acceptable — consumers only flag matches.
+ *   - No full POSIX expansion: backticks, $( ), $VAR, glob expansion are not
+ *     interpreted. A determined bypass via `$(echo grep) ...` is out of scope.
+ *   - `sudo`/`nice`/`time` are NOT unwrapped. Their flag/arg semantics vary
+ *     and would create false positives. Document this limitation in block
+ *     reasons rather than trying to parse it.
+ */
+
+// Transparent command-launcher wrappers: `command`, `exec`, `builtin`, `env`
+// all replace themselves with their first non-flag arg. Unwrapping these
+// closes common bypasses like `command grep`, `\grep`, `env FOO=1 grep`.
+const LAUNCHER = /^(command|exec|builtin|env)$/;
+const ENV_ASSIGN = /^[A-Za-z_][A-Za-z0-9_]*=/;
+
+function normalize(token) {
+  // Strip surrounding quotes, leading backslash-escape, and any path prefix so
+  // `"/usr/bin/grep"`, `\grep`, and `/bin/grep` all canonicalize to `grep`.
+  return token
+    .replace(/^["']+|["']+$/g, '')
+    .replace(/^\\/, '')
+    .split('/')
+    .pop();
+}
+
+function tokenize(segment) {
+  return segment.trim().split(/\s+/);
+}
+
+function stripPrefix(tokens) {
+  // Advance past leading env assignments and launcher wrappers (composable).
+  let i = 0;
+  while (i < tokens.length && ENV_ASSIGN.test(tokens[i])) i++;
+  while (i < tokens.length && LAUNCHER.test(normalize(tokens[i]))) {
+    i++;
+    while (i < tokens.length && ENV_ASSIGN.test(tokens[i])) i++;
+  }
+  return i;
+}
+
+function firstCommandWord(segment) {
+  const tokens = tokenize(segment);
+  const i = stripPrefix(tokens);
+  if (i >= tokens.length) return '';
+  return normalize(tokens[i]);
+}
+
+function commandTokens(segment) {
+  // Return [cmd, ...args], all normalized. Normalizing args (stripping quotes,
+  // path prefix) means `git "push" "origin" "main"` still matches an allow-list
+  // of `[git, push, origin, main]`.
+  const tokens = tokenize(segment);
+  const i = stripPrefix(tokens);
+  if (i >= tokens.length) return [];
+  return tokens.slice(i).map(normalize);
+}
+
+function splitTopLevel(cmd) {
+  // Split on top-level compound operators. Does not track quoting (see header).
+  return cmd.split(/(?:&&|\|\||;)/).map((s) => s.trim()).filter(Boolean);
+}
+
+function upstreamOfPipe(segment) {
+  // First pipe component: `a | b | c` -> `a`. `||` is not a pipe.
+  return segment.split(/\|(?!\|)/)[0].trim();
+}
+
+function isMultilineOrHeredoc(cmd) {
+  return cmd.includes('\n') || cmd.includes('<<');
+}
+
+module.exports = {
+  LAUNCHER,
+  ENV_ASSIGN,
+  normalize,
+  tokenize,
+  stripPrefix,
+  firstCommandWord,
+  commandTokens,
+  splitTopLevel,
+  upstreamOfPipe,
+  isMultilineOrHeredoc,
+};

--- a/hooks/output-protocols.md
+++ b/hooks/output-protocols.md
@@ -11,3 +11,5 @@ Respect these unless the user explicitly overrides (e.g. "full file", "verbose",
 4. **Telegram-style prose.** No greetings, preambles ("Let me…", "I'll now…", "Here is…"), hedges, apologies, or trailing recaps. Short content words; punctuation only where essential to meaning. Never re-describe what a tool call just did — its output is already visible.
 
 5. **Flat, short-key JSON.** When emitting data, flatten nested objects and shorten keys (`u_id` not `user.id`). Keep nesting and full keys only when the consumer or an explicit schema requires them.
+
+6. **Bash tool substitutes are guarded.** The `guard-bash-substitutes` PreToolUse hook blocks `grep`/`rg`/`egrep`/`fgrep`, `cat`/`head`/`tail`, and `find -name` (when no other predicate is present). All common bypass forms are also blocked: absolute paths (`/usr/bin/grep`, `/bin/cat`), quoted command words (`"/usr/bin/grep"`), backslash-escape (`\grep`), and launcher wrappers (`command grep`, `exec grep`, `builtin grep`, `env grep`, `env FOO=1 grep`). When blocked, switch to `Grep` / `Read` / `Glob` — do not retry variants. Escape hatch for genuinely-needed shell form: append `# bash-guard: allow` to the command.


### PR DESCRIPTION
## Summary
- Extract shared bash-parse helper (`hooks/lib/bash-parse.js`) so guards share identical tokenization/unwrap/segment-split logic.
- Close bypass variants in `guard-git-push` (path prefix, quotes, backslash-escape, launcher wrappers, chained/piped segments). Adds `# git-push-guard: allow` escape hatch.
- Extend `guard-write` to cover `NotebookEdit` (treats like Edit — records, never blocks) and GC state files older than 7 days.
- Document bypass-guard rules in `output-protocols.md` so the assistant learns them via SessionStart cache rather than block reasons.

## Test plan
- [x] Table tests (19 cases) for `guard-git-push` bypass forms — all block/allow as expected
- [x] Table tests (15 cases) for `guard-bash-substitutes` refactor — behavior unchanged
- [x] `guard-write` behavior tests (8 cases) — Write/Edit/NotebookEdit routing correct
- [x] `guard-write` GC test — old state files removed, fresh ones preserved
- [ ] Sync into live plugin cache and verify against real bash invocations